### PR TITLE
fix: fixed an infinite loop in a tokenizer

### DIFF
--- a/aqua/Cargo.toml
+++ b/aqua/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tergo-tokenizer"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["Konrad Pagacz konrad.pagacz@gmail.com"]
 description = "R language tokenizer"

--- a/aqua/src/tokenizer.rs
+++ b/aqua/src/tokenizer.rs
@@ -351,11 +351,15 @@ impl<'a> Tokenizer<'a> {
         let delimiter = self.current_char;
         let start_offset = self.offset;
         let start_it = self.it;
-        let mut previous_char = self.current_char;
+        let mut in_escape = false;
         self.next();
-        while self.current_char != delimiter || previous_char == '\\' {
-            previous_char = self.current_char;
+        while self.current_char != delimiter || in_escape {
             self.next();
+            if in_escape {
+                in_escape = !in_escape;
+            } else if self.current_char == '\\' {
+                in_escape = true;
+            }
         }
         tokens.push(CommentedToken::new(
             Literal(&self.raw_source[start_it..=self.it]),

--- a/aqua/tests/tokenizer_tests.rs
+++ b/aqua/tests/tokenizer_tests.rs
@@ -336,3 +336,15 @@ fn non_ascii_characters() {
         let _ = tokenizer.tokenize();
     }
 }
+
+#[test]
+fn escape_in_strings() {
+    log_init();
+
+    let examples = vec![".\\"];
+    for example in examples {
+        let mut tokenizer = Tokenizer::new(example);
+        let res = tokenizer.tokenize();
+        assert!(!res.is_empty())
+    }
+}

--- a/balnea/Cargo.toml
+++ b/balnea/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tergo-lib"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2021"
 description = "A tool to format R code"
 license = "MIT"
@@ -12,9 +12,9 @@ repository = "https://github.com/kpagacz/tergo/tree/main/balnea"
 path = "src/lib.rs"
 
 [dependencies]
-tokenizer = { package = "tergo-tokenizer", path = "../aqua", version = "0.2.2" }
-parser = { package = "tergo-parser", path = "../spongia", version = "0.2.3" }
-formatter = { package = "tergo-formatter", path = "../unguentum", version = "0.2.8" }
+tokenizer = { package = "tergo-tokenizer", path = "../aqua", version = "0.2.3" }
+parser = { package = "tergo-parser", path = "../spongia", version = "0.2.4" }
+formatter = { package = "tergo-formatter", path = "../unguentum", version = "0.2.9" }
 log = "0.4.21"
 env_logger = "0.11.3"
 serde = { version = "1.0.210", features = ["derive"] }

--- a/scopa/Cargo.toml
+++ b/scopa/Cargo.toml
@@ -9,7 +9,7 @@ path = "./src/lib.rs"
 
 [dependencies]
 wit-bindgen = "0.32.0"
-tergo-lib = { path = "../balnea", version = "0.2.8" }
+tergo-lib = { path = "../balnea", version = "0.2.10" }
 
 [dev-dependencies]
 wasm-tools = "1.217.0"

--- a/spongia/Cargo.toml
+++ b/spongia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tergo-parser"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 license = "MIT"
 description = "Parser for tergo"
@@ -12,7 +12,7 @@ repository = "https://github.com/kpagacz/tergo/tree/main/spongia"
 nom = "7.1.3"
 nom_locate = "4.2.0"
 anyhow = "1.0.81"
-tokenizer = { package = "tergo-tokenizer", path = "../aqua", version = "0.2.2" }
+tokenizer = { package = "tergo-tokenizer", path = "../aqua", version = "0.2.3" }
 log = "0.4.21"
 
 [dev-dependencies]

--- a/unguentum/Cargo.toml
+++ b/unguentum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tergo-formatter"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 license = "MIT"
 description = "Formatter for tergo"
@@ -9,8 +9,8 @@ repository = "https://github.com/kpagacz/tergo/tree/main/unguentum"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokenizer = { package = "tergo-tokenizer", path = "../aqua", version = "0.2.2" }
-parser = { package = "tergo-parser", path = "../spongia", version = "0.2.3" }
+tokenizer = { package = "tergo-tokenizer", path = "../aqua", version = "0.2.3" }
+parser = { package = "tergo-parser", path = "../spongia", version = "0.2.4" }
 log = "0.4.21"
 serde = { version = "1.0.210", features = ["derive"] }
 


### PR DESCRIPTION
* Fixed an infinite loop bug in the tokenizer for such inputs: `"\\"`.

Closes #39